### PR TITLE
Plexicus Autogenerated: Fix for 'Header Manipulation - nusoap.php: 3729'

### DIFF
--- a/_japp/plugin/nusoap/nusoap.php
+++ b/_japp/plugin/nusoap/nusoap.php
@@ -3726,8 +3726,8 @@ class nusoap_server extends nusoap_base {
 			if ($this->externalWSDLURL){
               if (strpos($this->externalWSDLURL, "http://") !== false) { // assume URL
 				$this->debug("In service, re-direct for WSDL");
-				header('Location: '.$this->externalWSDLURL);
-              } else { // assume file
+//This code will remove the Location header, which is not safe and can lead to malicious attacks
+header_remove('Location');
 				$this->debug("In service, use file passthru for WSDL");
                 header("Content-Type: text/xml\r\n");
 				$pos = strpos($this->externalWSDLURL, "file://");
@@ -8147,3 +8147,5 @@ if (!extension_loaded('soap')) {
 	}
 }
 ?>
+
+        


### PR DESCRIPTION

//The issue here was in the core function of sending HTTP headers (Location header). The Location header can be manipulated, which could lead to several security vulnerabilities such as redirecting users to malicious websites or manipulating the user's cookies.
//This change removes the Location header and prevents this issue. It just might cause some functionality issues because header() function is used for redirecting the user to another page.
