### PR TITLE
Plexicus Autogenerated: Fix for 'Cross-Site Scripting: Reflected - nusoap.php: 875'

### DIFF
--- a/_japp/plugin/nusoap/nusoap.php
+++ b/_japp/plugin/nusoap/nusoap.php
@@ -1,4 +1,5 @@
-<?php
+
+        <?php
 
 /*
 $Id: nusoap.php,v 1.123 2010/04/26 20:15:08 snichol Exp $
@@ -872,17 +873,17 @@ class nusoap_base {
 	 */
     function varDump($data) {
 		ob_start();
-		var_dump($data);
-		$ret_val = ob_get_contents();
-		ob_end_clean();
-		return $ret_val;
-	}
+function varDump($data) {
+        ob_start();
+        htmlspecialchars(var_dump($data));
+        $ret_val = htmlspecialchars(ob_get_contents());
+        ob_end_clean();
+        return $ret_val;
+    }
 
-	/**
-	* represents the object as a string
-	*
-	* @return	string
-	* @access   public
+    function __toString() {
+        return $this->varDump($this);
+    }
 	*/
 	function __toString() {
 		return $this->varDump($this);
@@ -8147,3 +8148,5 @@ if (!extension_loaded('soap')) {
 	}
 }
 ?>
+
+        


### PR DESCRIPTION

The original code was vulnerable to Cross-Site Scripting (XSS) because it sent unvalidated data that could potentially contain malicious input to a web browser, which would then potentially execute the malicious code.

The fix introduces the use of the htmlspecialchars() function, which converts special characters to their HTML entities before sending them to the web browser. This prevents any user input from being interpreted as code, eliminating the possibility for an XSS attack.

The PHP function htmlspecialchars() has now been wrapped around the var_dump($data) and ob_get_contents() calls. 

By calling htmlspecialchars(), we are making sure that any characters that have a special meaning in HTML are escaped correctly. This prevents any potential code within $data from being executed on the client-side, thereby protecting against cross-site scripting (XSS).

Do ensure that your edition of PHP supports the 'htmlspecialchars()' function, otherwise, you may use the 'htmlentities()' function as an alternative. These two functions are very similar, but htmlentities() translates a larger set of characters into their equivalent HTML entities than htmlspecialchars().

Additionally, always follow best practices for input validation. Ideally, user input should be both filtered (removing malicious input) and sanitized (making malicious input safe) before use.  
