### PR TITLE
Plexicus Autogenerated: Fix for 'Cross-Site Scripting: Reflected - nusoap.php: 875'

### DIFF
--- a/_japp/plugin/nusoap/nusoap.php
+++ b/_japp/plugin/nusoap/nusoap.php
@@ -1,4 +1,5 @@
-<?php
+
+        <?php
 
 /*
 $Id: nusoap.php,v 1.123 2010/04/26 20:15:08 snichol Exp $
@@ -872,17 +873,17 @@ class nusoap_base {
 	 */
     function varDump($data) {
 		ob_start();
-		var_dump($data);
-		$ret_val = ob_get_contents();
-		ob_end_clean();
-		return $ret_val;
-	}
+function varDump($data) {
+    ob_start();
+    var_dump(htmlspecialchars($data, ENT_QUOTES, 'UTF-8'));
+    $ret_val = ob_get_contents();
+    ob_end_clean();
+    return $ret_val;
+}
 
-	/**
-	* represents the object as a string
-	*
-	* @return	string
-	* @access   public
+function __toString() {
+    return $this->varDump($this);
+}
 	*/
 	function __toString() {
 		return $this->varDump($this);
@@ -8147,3 +8148,5 @@ if (!extension_loaded('soap')) {
 	}
 }
 ?>
+
+        


### PR DESCRIPTION

The original code was directly dumping the input data without validating or sanitizing it, which makes it vulnerable to Cross-Site Scripting attacks (XSS). Untrusted data supplied by the user was being returned directly without any sanitization.

In the fixed version of the code we have added the PHP function "htmlspecialchars()" to sanitize the data which is then dumped. The 'htmlspecialchars' function will convert special characters to their HTML entities, thus preventing possible script injection.
It is a good practice to always sanitize and validate any user supplied data to prevent any form of code injection attacks.
